### PR TITLE
Remove constructor and destructor declaration in GridMapCvConverter

### DIFF
--- a/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
+++ b/grid_map_cv/include/grid_map_cv/GridMapCvConverter.hpp
@@ -25,16 +25,6 @@ class GridMapCvConverter
 {
  public:
   /*!
-   * Default constructor.
-   */
-  GridMapCvConverter();
-
-  /*!
-   * Destructor.
-   */
-  virtual ~GridMapCvConverter();
-
-  /*!
    * Initializes the geometry of a grid map from an image. This changes
    * the geometry of the map and deletes all contents of the layers!
    * @param[in] image the image.


### PR DESCRIPTION
Having only the declarations yields to undefined references, so I removed them.